### PR TITLE
Update tags on file save and increased buffer size

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
 			"args": ["--extensionDevelopmentPath=${workspaceRoot}" ],
 			"stopOnEntry": false,
 			"sourceMaps": true,
-			"outDir": "out/src",
+			"outDir": "${workspaceRoot}/out/src",
 			"preLaunchTask": "npm"
 		},
 		{
@@ -21,7 +21,7 @@
 			"args": ["--extensionDevelopmentPath=${workspaceRoot}", "--extensionTestsPath=${workspaceRoot}/out/test" ],
 			"stopOnEntry": false,
 			"sourceMaps": true,
-			"outDir": "out/test",
+			"outDir": "${workspaceRoot}/out/test",
 			"preLaunchTask": "npm"
 		}
 	]

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,4 +20,5 @@ export function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(vscode.languages.registerDefinitionProvider(['cpp', 'c'], new DefinitionProvider(global)));
 	context.subscriptions.push(vscode.languages.registerDocumentSymbolProvider(['cpp', 'c'], new DocumentSymbolProvider(global)));
 	context.subscriptions.push(vscode.languages.registerReferenceProvider(['cpp', 'c'], new ReferenceProvider(global)));
+    context.subscriptions.push(vscode.workspace.onDidSaveTextDocument(d => global.updateTags()));
 }

--- a/src/global.ts
+++ b/src/global.ts
@@ -12,7 +12,7 @@ function execute(command: string): Promise<Buffer> {
     return exec(command, {
         cwd: vscode.workspace.rootPath,
         encoding: output,
-        maxBuffer: 1024*1024
+        maxBuffer: 10*1024*1024
     }).then(function(result): Buffer {
         if (encoding != null && encoding != "") {
             var decoded = iconv.decode(result.stdout, encoding);

--- a/src/global.ts
+++ b/src/global.ts
@@ -11,7 +11,8 @@ function execute(command: string): Promise<Buffer> {
     }
     return exec(command, {
         cwd: vscode.workspace.rootPath,
-        encoding: output
+        encoding: output,
+        maxBuffer: 1024*1024
     }).then(function(result): Buffer {
         if (encoding != null && encoding != "") {
             var decoded = iconv.decode(result.stdout, encoding);
@@ -30,6 +31,10 @@ export class Global {
 
     run(params: string[]): Promise<Buffer> {
         return execute(this.exec + ' ' + params.join(' '));
+    }
+
+    updateTags() {
+        this.run(['-u']);
     }
 
     parseLine(content: string): any {


### PR DESCRIPTION
* Added `global -u` call on file save. Incrementally updates GTAGS.  #12 
* Increased buffer size of child-process.exec to 10 MiB (default 200 kiB) to solve #10 
* Fixed absolute paths in launch.json. (Complained in Insiders build)