### PR TITLE
Ctrl+Hover no longer blocking and Win search improvement

### DIFF
--- a/src/features/completionItemProvider.ts
+++ b/src/features/completionItemProvider.ts
@@ -20,7 +20,7 @@ export default class GlobalCompletionItemProvider extends AbstractProvider imple
 		console.log(position);
 		var word = document.getText(document.getWordRangeAtPosition(position)).split(/\r?\n/)[0];
         var self = this;
-		return this._global.run(['-x', '^' + word + '.*'])
+		return this._global.run(['-x', '"^' + word + '.*"'])
 		.then(function(output){
 			console.log(output);
 			var bucket = new Array<vscode.CompletionItem>();

--- a/src/features/definitionProvider.ts
+++ b/src/features/definitionProvider.ts
@@ -28,9 +28,12 @@ export default class GlobalDefinitionProvider extends AbstractProvider implement
 				} else if (bucket.length == 0) {
 					return null;
 				}
-				return vscode.window.showQuickPick(bucket).then(value => {
-					return new vscode.Location(vscode.Uri.file(value.path), new vscode.Position(value.line, 0));
+				
+				var matches = new Array<vscode.Location>();
+				bucket.forEach((value, index, array) => {
+					matches.push(new vscode.Location(vscode.Uri.file(value.path), new vscode.Position(value.line, 0)));
 				});
+				return matches;
 			}
 			catch (ex){
 				console.error("Error: " + ex);


### PR DESCRIPTION
Changed behaviour of multiple definition matches to non-blocking for keyboard shortcuts. E.g. Ctrl+C now works when symbol gets highlighted using the mouse.

#15 